### PR TITLE
First stab at porting addtrans to Python3

### DIFF
--- a/bin/addtrans
+++ b/bin/addtrans
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import os

--- a/bin/sorttrans-cli
+++ b/bin/sorttrans-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import os

--- a/src/ledgerhelpers/editabletransactionview.py
+++ b/src/ledgerhelpers/editabletransactionview.py
@@ -23,7 +23,7 @@ class EditableTransactionView(Gtk.Grid):
         'payee-changed': (GObject.SIGNAL_RUN_LAST, None, ()),
     }
 
-    css = """
+    css = b"""
 editabletransactionview {
   border: 1px @borders inset;
   background: #fff;

--- a/src/ledgerhelpers/gui.py
+++ b/src/ledgerhelpers/gui.py
@@ -329,7 +329,7 @@ class EditableTabFocusFriendlyTextView(Gtk.TextView):
 
 class LedgerTransactionView(Gtk.Box):
 
-    css = """
+    css = b"""
 ledgertransactionview {
   border: 1px @borders inset;
 }

--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -266,7 +266,7 @@ class Journal(JournalCommon):
         if not isinstance(text, str):
             text = "\n".join(text)
         f = open(f, "a")
-        print(text, end=' ', file=f)
+        print(text, file=f)
         f.flush()
         f.close()
 

--- a/src/ledgerhelpers/legacy.py
+++ b/src/ledgerhelpers/legacy.py
@@ -155,6 +155,7 @@ def parse_date(putative_date, return_format=False):
             d = datetime.datetime.strptime(putative_date, f).date()
             break
         except ValueError as e:
+            last_exception = e
             continue
     try:
         if return_format:
@@ -162,7 +163,7 @@ def parse_date(putative_date, return_format=False):
         else:
             return d
     except UnboundLocalError:
-        raise ValueError("cannot parse date from format %s: %s" % (f, e))
+        raise ValueError("cannot parse date from format %s: %s" % (f, last_exception))
 
 
 def format_date(date_obj, sample_date):

--- a/src/ledgerhelpers/parser.py
+++ b/src/ledgerhelpers/parser.py
@@ -469,7 +469,7 @@ class LedgerTransactionLexer(GenericLexer):
 
     def state_parsing_transaction_posting_account(self):
         chars = []
-        if self.peek() in CHAR_COMMENT:
+        if self.more() and self.peek() in CHAR_COMMENT:
             return self.state_parsing_transaction_comment
         while self.more():
             if (

--- a/src/ledgerhelpers/programs/sorttranscli.py
+++ b/src/ledgerhelpers/programs/sorttranscli.py
@@ -66,7 +66,7 @@ def main(argv):
         rightcontents = "".join(i.contents for i in sort_transactions(items))
         if args.assume_yes:
             with open(ledgerfile, "w") as out_file:
-                out_file.write(rightcontents.encode("utf-8"))
+                out_file.write(rightcontents)
             return 0
         try:
             diffing.three_way_diff(ledgerfile, leftcontents, rightcontents)


### PR DESCRIPTION
Changed interpreter to python3 on sorttrans-cli and addtrans and fixed the following issues:
- changed css parameter type from `str` to expected `bytes`
- fixed an exception variable scoping issue
- fixed an encoding issue in sorttranscli.py
- removed trailing whitespace when adding transaction, which caused the file to be invalid
- improved the error message on encountering invalid posting: used to print just `NoneType: None` and show a mysterious error window like the following
   ![Zrzut ekranu z 2022-01-02 22-40-19](https://user-images.githubusercontent.com/489420/147890368-2b38e885-79c2-48f6-9827-ce2ff69cfb30.png)
   now a more useful message is shown:
   ![Zrzut ekranu z 2022-01-07 14-35-10](https://user-images.githubusercontent.com/489420/148552409-ebe344c4-f025-4b9d-9a16-5116edd64268.png)
 