### PR TITLE
Drop ansible dependency.

### DIFF
--- a/src/ledgerhelpers/legacy.py
+++ b/src/ledgerhelpers/legacy.py
@@ -3,7 +3,6 @@ import fcntl
 import struct
 import termios
 import tty
-from ansible.plugins.lookup import lines
 
 
 CURSOR_UP = "\033[F"


### PR DESCRIPTION
This does not seem to be used, probably added by an overzealous IDE?