### PR TITLE
Cleanup outside_mainloop remnants to prevent crash.

### DIFF
--- a/src/ledgerhelpers/gui.py
+++ b/src/ledgerhelpers/gui.py
@@ -49,7 +49,7 @@ def add_css(css):
     _css_adjusted[css] = True
 
 
-def FatalError(message, secondary=None, unused_outside_mainloop=False, parent=None):
+def FatalError(message, secondary=None, parent=None):
     d = Gtk.MessageDialog(
         parent,
         Gtk.DialogFlags.DESTROY_WITH_PARENT,
@@ -63,7 +63,7 @@ def FatalError(message, secondary=None, unused_outside_mainloop=False, parent=No
 
 
 def cannot_start_dialog(msg):
-    return FatalError("Cannot start program", msg, outside_mainloop=True)
+    return FatalError("Cannot start program", msg)
 
 
 class EagerCompletion(Gtk.EntryCompletion):


### PR DESCRIPTION
This (apparently leftover kwarg) prevents nice error reports (for example lack of ledger file configuration) due to the following exception:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/addtrans", line 11, in <module>
    sys.exit(addtrans.main())
  File "/usr/lib/python3/dist-packages/ledgerhelpers/programs/addtrans.py", line 247, in main
    journal, s = gui.load_journal_and_settings_for_gui(
  File "/usr/lib/python3/dist-packages/ledgerhelpers/gui.py", line 93, in load_journal_and_settings_for_gui
    cannot_start_dialog(str(e))
  File "/usr/lib/python3/dist-packages/ledgerhelpers/gui.py", line 66, in cannot_start_dialog
    return FatalError("Cannot start program", msg, outside_mainloop=True)
TypeError: FatalError() got an unexpected keyword argument 'outside_mainloop'
```