### PR TITLE
Prevent TypeError and AttributeError on missing file.

### DIFF
--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -189,6 +189,8 @@ class Journal(JournalCommon):
             self.internal_parsing_thread.setName("Internal reparser")
             self.internal_parsing_thread.start()
         else:
+            if self.internal_parsing_thread is None:
+                self.internal_parsing_thread = FakeThread()
             self.internal_parsing_cache_lock.release()
 
         return self.internal_parsing_thread

--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -125,7 +125,7 @@ class Journal(JournalCommon):
     slave = None
     slave_lock = None
     cache = None
-    internal_parsing_cache = None
+    internal_parsing_cache = []
     internal_parsing_cache_lock = None
     internal_parsing_thread = None
 

--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -202,15 +202,15 @@ class Journal(JournalCommon):
                 if result == UNCHANGED:
                     assert "accounts" in self.cache
                 else:
-                    accounts = result[0]
+                    accounts = result[0] if result[0] is not None else []
                     last_commodity_for_account = dict(
                         (acc, ledger.Amount(amt))
                         for acc, amt in list(result[1].items())
-                    )
+                    ) if result[1] is not None else {}
                     all_commodities = [
                         ledger.Amount(c)
                         for c in result[2]
-                    ]
+                    ] if result[2] is not None else []
                     self.cache["accounts"] = accounts
                     self.cache["last_commodity_for_account"] = (
                         last_commodity_for_account

--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -112,6 +112,11 @@ class JournalCommon():
         return unitext
 
 
+class FakeThread:
+    def join(self):
+        pass
+
+
 class Journal(JournalCommon):
 
     logger = logging.getLogger("journal.master")

--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -351,7 +351,8 @@ class JournalSlave(JournalCommon, Process):
             self.ledger_parsing_thread = Rpl()
             self.ledger_parsing_thread.setName("Ledger reparser")
             self.ledger_parsing_thread.start()
-
+        if self.ledger_parsing_thread is None:
+            self.ledger_parsing_thread = FakeThread()
         return (
             changed, self.ledger_parsing_thread
         )


### PR DESCRIPTION
If the journal file is missing, one gets a cryptic error such as:

```
  File "/usr/lib/python3/dist-packages/ledgerhelpers/journal.py", line 254, in internal_parsing
    self._cache_internal_parsing().join()
AttributeError: 'NoneType' object has no attribute 'join'
```

Fix that by returning an object with a join() method rather than None in that case.

After fixing that, one gets similar errors from other parts of the code which are unprepared to deal with a None value.

Fixed that by returning less surprising values as appropriate.

This way addtrans can start fine and create the file on first transaction addition.