### PR TITLE
Fix test under Python 3

### DIFF
--- a/tests/test_ledgerhelpers.py
+++ b/tests/test_ledgerhelpers.py
@@ -26,7 +26,7 @@ class TestJournal(T):
 
     def test_reload_works(self):
         with tempfile.NamedTemporaryFile() as f:
-            data = file(base.datapath("simple_transaction.dat")).read()
+            data = open(base.datapath("simple_transaction.dat")).read()
             f.write(data)
             f.flush()
             j = journal.Journal.from_file(f.name, None)

--- a/tests/test_ledgerhelpers.py
+++ b/tests/test_ledgerhelpers.py
@@ -25,7 +25,7 @@ class TestJournal(T):
         self.assertEqual(commos["Expenses:Drinking"], "1.00 CHF")
 
     def test_reload_works(self):
-        with tempfile.NamedTemporaryFile() as f:
+        with tempfile.NamedTemporaryFile(mode="w") as f:
             data = open(base.datapath("simple_transaction.dat")).read()
             f.write(data)
             f.flush()


### PR DESCRIPTION
The `file` builtin was dropped in Python 3, and `tempfile` functions use a default mode incompatible with `open`.