### PR TITLE
Print exception in a way that works outside exception context.

### DIFF
--- a/src/ledgerhelpers/programs/addtrans.py
+++ b/src/ledgerhelpers/programs/addtrans.py
@@ -146,7 +146,7 @@ class AddTransApp(AddTransWindow, gui.EscapeHandlingMixin):
             self.status.set_text("")
 
     def journal_load_failed(self, e):
-        traceback.print_exc()
+        traceback.print_exception(e)
         gui.FatalError(
             "Add transaction loading failed",
             "An unexpected error took place:\n%s" % e,


### PR DESCRIPTION
Trying to print a traceback in `journal_load_failed` is too late, just prints None.

This can be reproduced by running `addtrans` from v0.3.5 on a file that does not exist. See the following screenshot:
![Zrzut ekranu z 2022-10-28 18-27-33](https://user-images.githubusercontent.com/489420/198687141-e5974250-70f5-43f1-bdfe-0876ab6e8c83.png)
