### PR TITLE
Prevent TypeError on missing file.

### DIFF
--- a/src/ledgerhelpers/journal.py
+++ b/src/ledgerhelpers/journal.py
@@ -126,6 +126,7 @@ class Journal(JournalCommon):
     def __init__(self):
         """Do not instantiate directly.  Use class methods."""
         self.cache = {}
+        self.internal_parsing_cache = []
         self.internal_parsing_cache_lock = threading.Lock()
         self.slave_lock = threading.Lock()
 


### PR DESCRIPTION
Running `addtrans` pointing it at a file which does not exist first leads to the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/ledgerhelpers/gui.py", line 30, in f
    GObject.idle_add(success_func, func())
  File "/usr/lib/python3/dist-packages/ledgerhelpers/programs/addtrans.py", line 120, in <lambda>
    lambda: self.journal.all_payees(),
  File "/usr/lib/python3/dist-packages/ledgerhelpers/__init__.py", line 48, in f
    return kallable(*a, **kw)
  File "/usr/lib/python3/dist-packages/ledgerhelpers/journal.py", line 246, in all_payees
    for xact in self.internal_parsing():
TypeError: 'NoneType' object is not iterable
```

This change addresses this issue.

Note, the above stack trace only becomes visible when with #27 applied.