### PR TITLE
Get rid of options.data_files altogether

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,27 +35,5 @@ scripts =
     bin/updateprices
     bin/withdraw-cli
 
-[options.data_files]
-share/applications =
-    applications/withdraw-cli.desktop
-    applications/cleartrans-cli.desktop
-    applications/sortttrans-cli.desktop
-    applications/updateprices.desktop
-    applications/sellstock-cli.desktop
-    applications/addtrans.desktop
-share/doc/ledgerhelpers =
-    doc/addrans.md
-    doc/addtrans-account.png
-    doc/addtrans-amount.png
-    doc/addtrans-dropdown.png
-    doc/addtrans-readyagain.png
-    doc/addtrans-started-up.Programming
-share/man/man1 =
-    man/addtrans.1
-    man/cleartrans-cli.1
-    man/sellstock-cli.1
-    man/sorttrans-cli.1
-    man/withdraw-cli.1
-
 [options.packages.find]
 where = src


### PR DESCRIPTION
Related to this, we will need new install instructions for these files now, but note that the install instructions are out of date anyway as of 0eb0540fa08f4ec463b7c660bfda10756e12a23c. I do not know the proper new incantation since I rely on the debhelper magic to DTRT for me.