### PR TITLE
Stop using pipes, fix write arg type.

### DIFF
--- a/tests/dogtail/addtrans.py
+++ b/tests/dogtail/addtrans.py
@@ -2,7 +2,7 @@
 # Dogtail test script for addtrans.
 
 import os
-import pipes
+import shlex
 import tempfile
 
 from dogtail import config
@@ -33,11 +33,11 @@ t.write("""
 2015-10-05 * beer
     Assets:Cash                       -30 CHF
     Expenses:Drinking                  30 CHF
-""")
+""".encode())
 t.flush()
 t.seek(0, 0)
 
-run('addtrans --file %s' % pipes.quote(t.name))
+run(shlex.join(['addtrans', '--file', t.name]))
 addtrans = tree.root.application('addtrans')
 mainwin = addtrans.window('Add transaction')
 


### PR DESCRIPTION
Fixes:

```
.../ledgerhelpers/tests/dogtail/addtrans.py:5: DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
```

and

```
Traceback (most recent call last):
  File ".../ledgerhelpers/tests/dogtail/addtrans.py", line 32, in <module>
    t.write("""
  File "/usr/lib/python3.11/tempfile.py", line 638, in func_wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: a bytes-like object is required, not 'str'
```

This still leaves the following which I have no idea how to fix:

```
(addtrans:4027391): Gtk-WARNING **: 22:02:06.703: Locale not supported by C library.
	Using the fallback 'C' locale.
dbus[4027379]: arguments to dbus_connection_send_with_reply_and_block() were incorrect, assertion "(error) == NULL || !dbus_error_is_set ((error))" failed in file ../../../dbus/dbus-connection.c line 3557.
This is normally a bug in some application using the D-Bus library.

  D-Bus not built with -rdynamic so unable to print a backtrace
Aborted
```
